### PR TITLE
Fixed code to work with both upper, lowercase HTTP headers

### DIFF
--- a/src/IconScraper/DataAccess.php
+++ b/src/IconScraper/DataAccess.php
@@ -16,7 +16,10 @@ class DataAccess {
 	
     public function retrieveHeader($url) {
         $this->setContext();
-        return @get_headers($url, TRUE);
+
+        $headers = @get_headers($url, TRUE);
+
+        return array_change_key_case($headers);
     }
 	
     public function saveCache($file, $data) {

--- a/src/IconScraper/Scraper.php
+++ b/src/IconScraper/Scraper.php
@@ -90,7 +90,7 @@ class Scraper
             switch ($status) {
                 case '301':
                 case '302':
-                    $url = $headers['Location'];
+                    $url = $headers['location'];
                     break;
                 default:
                     $loop = false;


### PR DESCRIPTION
According to RFC headers are case insensitive https://www.w3.org/Protocols/rfc2616/rfc2616.html

`Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.`

This pull request fixes a hard coded use of `Location` header

